### PR TITLE
Atualiza fundo azul da página de agradecimento

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,8 +59,7 @@
         /* Página de Obrigado */
         .obrigado-page {
             min-height: 100vh;
-            background: linear-gradient(135deg, rgba(59, 130, 197, 0.9), rgba(44, 62, 80, 0.8)), 
-                        url('https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80') center/cover no-repeat;
+            background: #1E5677;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -216,7 +215,7 @@
         }
 
         /* Loader para caso a imagem demore para carregar */
-        .obrigado-page::before {
+        /* .obrigado-page::before {
             content: '';
             position: absolute;
             top: 0;
@@ -225,7 +224,7 @@
             bottom: 0;
             background: linear-gradient(135deg, rgba(59, 130, 197, 0.9), rgba(44, 62, 80, 0.8));
             z-index: 1;
-        }
+        } */
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- troca background da seção `.obrigado-page` para azul sólido
- remove sobreposição visual comentando o pseudo-elemento `.obrigado-page::before`

## Testing
- `npm test` (fails: missing package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fcca02c2c8320bb4f0575f55eded2