### PR TITLE
Make body background transparent

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
             line-height: 1.6;
             color: #2c3e50;
-            background-color: #f8fafc;
+            background-color: transparent;
             min-height: 100vh;
             overflow-x: hidden;
         }


### PR DESCRIPTION
## Summary
- use transparent background for body in index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd49da1f083209d505b771587f9cf